### PR TITLE
fixing README.md to be updated in the profile folder instead of the root

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,9 @@
+## Hi there and welcome to my organisation 👋
+
+🙋‍♀️ This organisation will contain all RimWorld related modding stuff, it will make everything easier for automation and consistency in my mod's repositories.
+
+🌈 Contribution guidelines - see the issues and enhancement/feature templates when submitting issues, and adding labels upon them so they are labeled on the project board.
+I have set the project board for DogApparel public, so people can see what we are working on etc. When you have submit an issue, you can see when it is scheduled. 
+
+👩‍💻 Useful resources - I have made templates so one can easier find a way to make our workflow easier to manage see .github repository for default files and community health files.
+we are also open for discussions or submitting issues for any mods, and dicussions will be in the organization level for the DogApparel mod taken as example for discussion form. 


### PR DESCRIPTION
The README didn't show up when it was placed in the root of the GitHub repo that contains the config files of the organization. So I copied the text from readme.md from the root of the repo and pasted it back into a new .github/profile/README.md